### PR TITLE
Fix: responsive behavior on the result page search & sort

### DIFF
--- a/src/pages/homepage.jsx
+++ b/src/pages/homepage.jsx
@@ -15,18 +15,18 @@ const Homepage = () => {
   if (stockDetails.length > 0) {
     return (
       <div className="pt-20 container mx-auto flex flex-col h-screen p-2">
-        <div className="py-2 rounded-md flex justify-between items-center px-3">
-          <div className="flex bg-white py-2 border-[0.5px] rounded-md items-center gap-2 px-2">
+        <div className="py-2 rounded-md flex-col gap-y-2 sm:gap-y-0 sm:flex-row flex justify-between items-center px-3">
+          <div className="flex bg-white w-full sm:w-fit py-2 border-[0.5px] rounded-md items-center gap-2 px-2">
             <Search className="h-5 w-5 text-muted-foreground" />
             <input
               type="text"
-              className="px-2 outline-none"
+              className="px-2 outline-none w-full"
               placeholder="Search..."
               value={search}
               onChange={(ev) => setSearch(ev.target.value)}
             />
           </div>
-          <div className="flex gap-3 items-center">
+          <div className="flex gap-3 w-full sm:w-fit  items-center justify-between sm:justify-normal ">
             <select
               onChange={(e) => setShortBy(e.currentTarget.value)}
               className="bg-slate-200 p-2 rounded-md"


### PR DESCRIPTION
Fix issue [16](https://github.com/shivamsouravjha/stock-frontend/issues/16)
Made the results page top section (Search and sorting) responsive
Current small screen view
![small screen view](https://github.com/user-attachments/assets/684375fd-7b63-4c4e-8c08-75a736b0914a)
